### PR TITLE
Allow CIDR block for cluster to be configured per-Fabric.

### DIFF
--- a/ci/dockerize.py
+++ b/ci/dockerize.py
@@ -88,7 +88,7 @@ def main(args):
     version = gradle('--quiet version')
     is_tag = os.getenv('TRAVIS_TAG') not in ['', None]
     is_pull_request = os.getenv('TRAVIS_PULL_REQUEST', 'false') != 'false'
-    pull_request_number = os.getenv('TRAVIS_PULL_REQUEST_NUMBER')
+    pull_request_number = os.getenv('TRAVIS_PULL_REQUEST')
     build_number = os.getenv('TRAVIS_BUILD_NUMBER')
 
     if is_pull_request:

--- a/ci/dockerize.py
+++ b/ci/dockerize.py
@@ -112,7 +112,7 @@ def main(args):
 
         docker('build {0} --build-arg IMPL_VERSION={1} .'.format(tags, version))
 
-    if args['--push']:
+    if not is_pull_request and args['--push']:
         docker('push {}'.format(docker_repo))
     else:
         print("==> Skipping Docker image push")

--- a/src/main/kotlin/io/datawire/loom/proto/fabric/FabricManager.kt
+++ b/src/main/kotlin/io/datawire/loom/proto/fabric/FabricManager.kt
@@ -5,8 +5,6 @@ import io.datawire.loom.proto.aws.symlinkAwsConfig
 import io.datawire.loom.proto.core.ExternalTool
 import io.datawire.loom.proto.data.AwsS3Dao
 import io.datawire.loom.proto.exception.*
-import io.datawire.loom.proto.fabric.kops.KopsTool
-import io.datawire.loom.proto.fabric.kops.KopsToolContext
 import io.datawire.loom.proto.fabric.terraform.*
 import io.datawire.loom.proto.model.*
 import java.nio.file.Files
@@ -68,7 +66,7 @@ class FabricManager(private val terraform     : ExternalTool,
         ))
 
         val networking = generateNetworkingModule(model.networking.module, mapOf(
-                "cidr_block"       to "10.0.0.0/16",
+                "cidr_block"       to fabric.networkCidr,
                 "name"             to fabric.name
         ))
 

--- a/src/main/kotlin/io/datawire/loom/proto/model/Fabric.kt
+++ b/src/main/kotlin/io/datawire/loom/proto/model/Fabric.kt
@@ -6,6 +6,6 @@ data class Fabric(
         val model             : String,
         val clusterName       : String?,
         val networkId         : String?,
-        val networkCidr       : String?,
+        val networkCidr       : String = "30.0.0.0/16",
         val availabilityZones : List<String> = emptyList(),
         val status            : FabricStatus = FabricStatus.NOT_STARTED)

--- a/src/main/kotlin/io/datawire/loom/proto/model/FabricModel.kt
+++ b/src/main/kotlin/io/datawire/loom/proto/model/FabricModel.kt
@@ -23,7 +23,7 @@ data class FabricModel(
         val domain: String,
 
         @JsonProperty("networking")
-        val networking: FabricNetworkingModel = FabricNetworkingModel("github.com/datawire/loom//src/terraform/network-v2"),
+        val networking: FabricNetworkingModel = FabricNetworkingModel("github.com/datawire/loom//src/terraform/network-nosub"),
 
         @JsonProperty("masterType")
         val masterType: String = "t2.small",


### PR DESCRIPTION
- Assign 30.0.0.0/16 as the default CIDR to hopefully avoid most folks
  with 10.0.0.0/16 and similarly close ranges being in conflict when
  a CIDR is not provided.